### PR TITLE
Update sbt and migrate publishing to GitLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -13,14 +13,22 @@ This is a Work In Progress...
 ## Installation
 
 ```
-resolvers += Resolver.url("Agilogy Scala",url("http://dl.bintray.com/agilogy/scala/"))(Resolver.ivyStylePatterns)
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
 
-libraryDependencies += "com.agilogy" %% "srdb-types" % "1.0.1"
+libraryDependencies += "com.agilogy" %% "srdb-types" % "2.1"
 ```
 
 ## Usage
 
 TO-DO
+
+## Publishing
+
+To publish this package to Agilogy's Package Registry, set the `GITLAB_DEPLOY_TOKEN` environment variable and then run the following command in sbt:
+
+```
+sbt:simple-db> +publish
+```
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This is a Work In Progress...
 ## Installation
 
 ```
-resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/-/packages/maven"
 
-libraryDependencies += "com.agilogy" %% "srdb-types" % "2.2"
+libraryDependencies += "com.agilogy" %% "srdb-types" % "2.2.1"
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ TO-DO
 To publish this package to Agilogy's Package Registry, set the `GITLAB_DEPLOY_TOKEN` environment variable and then run the following command in sbt:
 
 ```
-sbt:simple-db> +publish
+sbt:srdb-types> +publish
 ```
 
 ## Copyright

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a Work In Progress...
 ```
 resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
 
-libraryDependencies += "com.agilogy" %% "srdb-types" % "2.1"
+libraryDependencies += "com.agilogy" %% "srdb-types" % "2.2"
 ```
 
 ## Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,16 @@
-import bintray.Keys._
 import com.typesafe.sbt.GitPlugin.autoImport._
 import com.typesafe.sbt.GitVersioning
+import com.gilcloud.sbt.gitlab.{GitlabCredentials,GitlabPlugin}
 
 organization := "com.agilogy"
 
 name := "srdb-types"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.13"
 
-crossScalaVersions := Seq("2.10.6","2.11.7","2.12.6")
+crossScalaVersions := Seq("2.11.7","2.12.13")
 
-resolvers += Resolver.url("Agilogy Scala",url("http://dl.bintray.com/agilogy/scala/"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("Agilogy Scala",url("https://dl.bintray.com/agilogy/scala/"))(Resolver.ivyStylePatterns)
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41" % "test",
@@ -79,38 +79,31 @@ scalastyleFailOnError := true
 
 // Reformat at every compile.
 // See https://github.com/sbt/sbt-scalariform
-scalariformSettings
 
 coverageExcludedPackages := "<empty>"
 
 coverageHighlighting := false
 
-Boilerplate.settings
+enablePlugins(spray.boilerplate.BoilerplatePlugin)
 
-// --> bintray
+// --> gitlab
 
-Seq(bintrayPublishSettings:_*)
+GitlabPlugin.autoImport.gitlabGroupId := None
+GitlabPlugin.autoImport.gitlabProjectId := Some(26236490)
+GitlabPlugin.autoImport.gitlabDomain := "gitlab.com"
 
-repository in bintray := "scala"
+GitlabPlugin.autoImport.gitlabCredentials := {
+    val token = sys.env.get("GITLAB_DEPLOY_TOKEN") match {
+        case Some(token) => token
+        case None =>
+            sLog.value.warn(s"Environment variable GITLAB_DEPLOY_TOKEN is undefined, 'publish' will fail.")
+            ""
+    }
+    Some(GitlabCredentials("Deploy-Token", token))
+}
 
-bintrayOrganization in bintray := Some("agilogy")
-
-packageLabels in bintray := Seq("scala")
-
-licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-
-// <-- bintray
+// <-- gitlab
 
 enablePlugins(GitVersioning)
 
 git.useGitDescribe := true
-
-resolvers += "Agilogy snapshots" at "http://188.166.95.201:8081/content/groups/public"
-
-publishMavenStyle := isSnapshot.value
-
-publishTo := {
-  val nexus = "http://188.166.95.201:8081/content/repositories/snapshots"
-  if (isSnapshot.value) Some("snapshots"  at nexus)
-  else publishTo.value
-}

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := "2.12.13"
 
 crossScalaVersions := Seq("2.11.7","2.12.13")
 
-resolvers += Resolver.url("Agilogy Scala",url("https://dl.bintray.com/agilogy/scala/"))(Resolver.ivyStylePatterns)
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := "2.12.13"
 
 crossScalaVersions := Seq("2.11.7","2.12.13")
 
-resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/-/packages/maven"
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41" % "test",

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,6 +1,0 @@
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-    Resolver.ivyStylePatterns)
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,10 +6,12 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")
 
-addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.5.9")
+addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+
+addSbtPlugin("com.gilcloud" % "sbt-gitlab" % "0.0.6")

--- a/src/main/scala/com/agilogy/srdb/types/ColumnReadException.scala
+++ b/src/main/scala/com/agilogy/srdb/types/ColumnReadException.scala
@@ -11,7 +11,7 @@ trait ColumnReadException extends RuntimeException {
 }
 
 case class ColumnReadExceptionWithCause(columnName: String, cause: Throwable, availableColumns: Option[Seq[(String, Any)]])
-    extends RuntimeException(ColumnReadExceptionWithCause.getMessage(columnName, cause, availableColumns), cause) with ColumnReadException {
+  extends RuntimeException(ColumnReadExceptionWithCause.getMessage(columnName, cause, availableColumns), cause) with ColumnReadException {
 
   override def getMessage: String =
     s"""
@@ -47,7 +47,7 @@ private[types] object Utilities {
 }
 
 case class NullColumnReadException(columnName: String, availableColumns: Option[Seq[(String, Any)]])
-    extends RuntimeException(NullColumnReadException.getMessage(columnName, availableColumns)) with ColumnReadException {
+  extends RuntimeException(NullColumnReadException.getMessage(columnName, availableColumns)) with ColumnReadException {
 }
 
 object NullColumnReadException {

--- a/src/main/scala/com/agilogy/srdb/types/ColumnType.scala
+++ b/src/main/scala/com/agilogy/srdb/types/ColumnType.scala
@@ -171,8 +171,7 @@ trait ColumnTypeInstances {
       if (jbd == null) null
       else jbd
     },
-    JdbcType.Numeric
-  )
+    JdbcType.Numeric)
 
   /** @group Column type instances */
   implicit val DbBigInt: ColumnType[BigInt] = DbBigDecimal.xmap[BigInt](_.toBigIntExact.get, bi => BigDecimal(bi).bigDecimal)


### PR DESCRIPTION
Bintray is shutting down on May 1st, so we are moving to a different platform.
Packages for `srdb-types` are already published on [Agilogy's Package Registry](https://gitlab.com/groups/agilogy/-/packages) on GitLab.
Please also add the `v2.2.1` tag to the most recent commit of this PR.